### PR TITLE
(GH-20) Add additional executable names

### DIFF
--- a/src/Cake.Kudu/KuduSync/KuduSyncRunner.cs
+++ b/src/Cake.Kudu/KuduSync/KuduSyncRunner.cs
@@ -101,7 +101,7 @@ namespace Cake.Kudu.KuduSync
         /// <returns>The tool executable name.</returns>
         protected override IEnumerable<string> GetToolExecutableNames()
         {
-            return new[] { "KuduSync.NET.exe" };
+            return new[] { "KuduSync.NET.exe", "kudusync.exe", "kudusync" };
         }
     }
 }


### PR DESCRIPTION
## Description
This will allow resolving the unofficial KuduSync.Tool executables.

## Related Issue
#20 

## Motivation and Context
Without it, only the full .Net Framework version of KuduSync can be used.

## How Has This Been Tested?
Locally, and proved that tool is resolved correctly.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
